### PR TITLE
PHP 8 / DokuWiki "Igor" compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Editor and temporary files
+*.swp
+*.bak
+*.old
+*~
+*.DS_Store
+*.iml
+.idea/
+.buildpath
+.project
+.settings/

--- a/README.md
+++ b/README.md
@@ -1,15 +1,29 @@
 # htmlmetatags Plugin for DokuWiki
-Dokuwiki-Plugin: Adds some (open graph) meta tags to the html header (e.g. keywords, description or any others)
 
+Dokuwiki-Plugin: Adds some (open graph) meta tags to the html header 
+(e.g. keywords, description or any others).
 
-Set html meta tags.
+All documentation for this plugin can be found at 
+https://www.dokuwiki.org/plugin:htmlmetatags
 
-All documentation for this plugin can be found athttps://www.dokuwiki.org/plugin:htmlmetatags
+If you install this plugin manually, make sure it is installed in 
+`lib/plugins/htmlmetatags/` - if the folder is called differently 
+it will not work!
 
-If you install this plugin manually, make sure it is installed inlib/plugins/htmlmetatags/ - if the folder is called different itwill not work!
+Please refer to http://www.dokuwiki.org/plugins for additional info on 
+how to install plugins in DokuWiki.
 
-Please refer to http://www.dokuwiki.org/plugins for additional info on how to install plugins in DokuWiki.
-----Copyright (C) Heiko Heinz <heiko.heinz@soft2c.de>
-This program is free software; you can redistribute it and/or modifyit under the terms of the GNU General Public License as published bythe Free Software Foundation; version 2 of the License
-This program is distributed in the hope that it will be useful,but WITHOUT ANY WARRANTY; without even the implied warranty ofMERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See theGNU General Public License for more details.
+----
+
+Copyright (C) Heiko Heinz <heiko.heinz@soft2c.de>
+
+This program is free software; you can redistribute it and/or modify it 
+under the terms of the GNU General Public License as published by the 
+Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful, but WITHOUT 
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for 
+more details.
+
 See the COPYING file in your DokuWiki folder for details

--- a/action.php
+++ b/action.php
@@ -72,12 +72,11 @@ class action_plugin_htmlmetatags extends DokuWiki_Action_Plugin {
     public function handle_htmlmetatags(Doku_Event &$event, $param) {
     
       global $ID;
-      global $conf;
       if (empty($event->data)) return; // nothing to do for us
       
       $metadata = p_get_metadata($ID);
-      
-      $a = $metadata["htmlmetatags"];
+
+      $a = $metadata["htmlmetatags"] ?? '';
       if(empty($a)) return;
       
       foreach(array_keys($a) as $cur_key) {

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   htmlmetatags
 author Heiko Heinz
 email  heiko.heinz@soft2c.de
-date   2017-04-24
+date   2022-09-26
 name   htmlmetatags plugin
 desc   Set html and open graph meta tags.
-url    https://www.dokuwiki.org/plugin:htmlmetatags
+url    https://www.dokuwiki.org/plugin:htmlmetatags

--- a/syntax/syntax.php
+++ b/syntax/syntax.php
@@ -104,7 +104,7 @@ class syntax_plugin_htmlmetatags_syntax extends DokuWiki_Syntax_Plugin {
                  	      $content = ml($content, '', true, '&amp;', true);
                     }
                     // Send result to renderer
-                    if (!empty($content)) {
+                    if (!empty($content) && isset($renderer->meta['htmlmetatags'])) {
                       if ($name == "keywords") {
                         if (!empty($renderer->meta['htmlmetatags'][$name]))
                           $renderer->meta["htmlmetatags"][$name] .= ', '.$content;


### PR DESCRIPTION
Tested the plugin with latest DokuWiki release on PHP 8.1; https://www.dokuwiki.org/plugin:htmlmetatags has been updated accordingly.
